### PR TITLE
Add wrappers for deep.equal and not.deep.equal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,40 @@ I.assertNotEqual('foobar', 'foo');
 -   `actualValue` - actual value
 -   `expectedValue` - expected value
 
+## assertDeepEqual
+
+Asserts that the target is an object whose properties are strictly equal (===) as the given value's.
+
+- https://www.chaijs.com/api/bdd/#method_deep
+- https://www.chaijs.com/api/bdd/#method_equal
+
+```js
+I.assertDeepEqual({a: 1}, {a: 1});
+```
+
+**Parameters**
+
+-   `actualValue` - actual value
+-   `expectedValue` - expected value
+
+## assertNotDeepEqual
+
+Asserts that the target is not an object whose properties are strictly equal (===) as the given value's.
+
+- https://www.chaijs.com/api/bdd/#method_not
+- https://www.chaijs.com/api/bdd/#method_deep
+- https://www.chaijs.com/api/bdd/#method_equal
+
+```js
+I.assertNotDeepEqual({a: 1}, {a: 2});
+I.assertNotDeepEqual({a: 1}, {b: 1, c: 2});
+```
+
+**Parameters**
+
+-   `actualValue` - actual value
+-   `expectedValue` - expected value
+
 ## assertContain
 
 Asserts that the target contains the given value.

--- a/index.js
+++ b/index.js
@@ -34,6 +34,29 @@ class chaiWrapper extends Helper {
   }
 
   /**
+   * https://www.chaijs.com/api/bdd/#method_deep
+   * https://www.chaijs.com/api/bdd/#method_equal
+   * @param {*} actualValue
+   * @param {*} expectedValue
+   * @returns {*}
+   */
+  assertDeepEqual(actualValue, expectedValue) {
+    return expect(actualValue).to.deep.equal(expectedValue);
+  }
+
+  /**
+   * https://www.chaijs.com/api/bdd/#method_not
+   * https://www.chaijs.com/api/bdd/#method_deep
+   * https://www.chaijs.com/api/bdd/#method_equal
+   * @param {*} actualValue
+   * @param {*} expectedValue
+   * @returns {*}
+   */
+  assertNotDeepEqual(actualValue, expectedValue) {
+    return expect(actualValue).to.not.deep.equal(expectedValue);
+  }
+
+  /**
    * https://www.chaijs.com/api/bdd/#method_include
    * @param {*} actualValue
    * @param {*} expectedValueToContain


### PR DESCRIPTION
@SitamJana I saw that there were no wrappers for the deep equality check so I decided to add some! Let me know if I should do something different or there was a reason this wasn't added yet. Thanks for this library!