### PR TITLE
Adding support for deep member comparison on arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,3 +568,51 @@ I.assertLengthAboveThan('foo', 4, 'Target length or size not below than given nu
 -   `targetData` - target data
 -   `lengthBelowThan` - length below than
 -   `customErrorMsg` - Custom error message
+
+## assertEqualsIgnoreCase
+
+Asserts two strings represent the same value when ignoring case
+
+https://www.chaijs.com/plugins/chai-string/
+
+```js
+I.assertEqualIgnoreCase('FOO','foo')
+```
+
+**Parameters**
+
+-   `actualValue` - actual value
+-   `expectedValue` - expected value
+-   `customErrorMsg` - Custom error message
+
+## assertDeepMembers
+
+Asserts members of two arrays are deeply equal
+
+https://www.chaijs.com/api/bdd/#method_deep
+
+```js
+I.assertDeepMembers([{a: 1}],[{a: 1}])
+```
+
+**Parameters**
+
+-   `actualValue` - actual value
+-   `expectedValue` - expected value
+-   `customErrorMsg` - Custom error message
+
+## assertDeepMembers
+
+Asserts an array deep includes members from another array
+
+https://www.chaijs.com/api/bdd/#method_deep
+
+```js
+I.assertDeepIncludeMembers([{a: 1},{b: 2}],[{a: 1}])
+```
+
+**Parameters**
+
+-   `actualValue` - actual value
+-   `expectedValue` - expected value
+-   `customErrorMsg` - Custom error message

--- a/index.js
+++ b/index.js
@@ -371,6 +371,34 @@ class chaiWrapper extends Helper{
 
   }
 
+  /**
+   * Asserts members of two arrays are deeply equal
+   * https://www.chaijs.com/api/bdd/#method_deep
+   * @param {*} actualValue 
+   * @param {*} expectedValue 
+   * @param {*} customErrorMsg 
+   * @returns 
+   */
+  assertDeepMembers( actualValue, expectedValue, customErrorMsg = '' ){
+
+    return expect( actualValue, customErrorMsg ).to.have.deep.members( expectedValue );
+
+  }
+
+  /**
+   * Asserts an array deep includes members from another array
+   * https://www.chaijs.com/api/bdd/#method_deep
+   * @param {*} actualValue 
+   * @param {*} expectedValue 
+   * @param {*} customErrorMsg 
+   * @returns 
+   */
+  assertDeepIncludeMembers( actualValue, expectedValue, customErrorMsg = '' ){
+
+    return expect( actualValue, customErrorMsg ).to.deep.include.members( expectedValue );
+
+  }
+
 }
 
 module.exports = chaiWrapper;


### PR DESCRIPTION
This PR will add `assertDeepMembers` and `assertDeepIncludeMembers` to the available assertions following Chai's documentation for [deep](https://www.chaijs.com/api/bdd/#method_deep).

```js
// Target array deeply (but not strictly) has member `{a: 1}`
expect([{a: 1}]).to.have.deep.members([{a: 1}]);
expect([{a: 1}]).to.not.have.members([{a: 1}]);

// Target object deeply (but not strictly) includes `x: {a: 1}`
expect({x: {a: 1}}).to.deep.include({x: {a: 1}});
expect({x: {a: 1}}).to.not.include({x: {a: 1}});
```

Also updating README documentation to include a miss from my last PR for `assertEqualIgnoreCase`